### PR TITLE
PN-18238: simplify private API schema by removing validation rules.

### DIFF
--- a/docs/openapi/api-private.yaml
+++ b/docs/openapi/api-private.yaml
@@ -257,9 +257,6 @@ components:
         internalRecipientId:
           description: ID of the recipient for internal use
           type: string
-          pattern: "^[ -~]{8,64}$"
-          minLength: 8
-          maxLength: 64
         recipientId:
           description: ID of the recipient (tax code)
           type: string

--- a/docs/openapi/api-private.yaml
+++ b/docs/openapi/api-private.yaml
@@ -264,21 +264,12 @@ components:
           description: ID of the recipient (tax code)
           type: string
           x-field-extra-annotation: "@lombok.ToString.Exclude"
-          pattern: "^[ -~]{8,64}$"
-          minLength: 8
-          maxLength: 64
         senderDescription:
           description: Description of the subject who originated the message
           type: string
-          pattern: "^[ -~]{1,88}$"
-          minLength: 1
-          maxLength: 88
         originId:
           description: ID of the original message
           type: string
-          pattern: "^[ -~]{24,36}$"
-          minLength: 24
-          maxLength: 36
         associatedPayment:
           description: The notification has an associated payment
           type: boolean


### PR DESCRIPTION
Removed regex and length limits to prevent validation duplication. Downstream emd services will act as the single source of truth for data integrity.